### PR TITLE
Single Line Comment Annotation Modularity 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+all:
+	make clean build test
+
 clean:
 	rm -rf ./bin
 
@@ -12,4 +15,4 @@ coverage:
 	go clean -testcache && go test -coverprofile=coverage/coverage.out ./... && go tool cover -html=coverage/coverage.out -o=coverage/coverage.html
 
 
-.PHONY: clean build run test coverage
+.PHONY: all clean build test coverage

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ build:
 test:
 	go test -v ./...
 
+lint:
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run -v
+
 coverage:
 	go clean -testcache && go test -coverprofile=coverage/coverage.out ./... && go tool cover -html=coverage/coverage.out -o=coverage/coverage.html
 
 
-.PHONY: all clean build test coverage
+.PHONY: all clean build test coverage lint

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -97,7 +97,7 @@ var ScanCmd = &cobra.Command{
 				fmt.Printf(
 					"Tag Located in %s on Line number: %d. Description: %s\n",
 					t.FileInfo.Name(),
-					t.LineNumber,
+					t.AnnotationLineNum,
 					t.Description,
 				)
 			}

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -95,9 +95,10 @@ var ScanCmd = &cobra.Command{
 
 			for _, t := range tags {
 				fmt.Printf(
-					"Tag Located in %s on Line number: %d. Description: %s\n",
+					"Tag Located in %s on Line number: %d. Title: %s Description: %s\n",
 					t.FileInfo.Name(),
 					t.AnnotationLineNum,
+					t.Title,
 					t.Description,
 				)
 			}

--- a/pkg/tag/comment.go
+++ b/pkg/tag/comment.go
@@ -2,10 +2,12 @@
 This file contains the comment syntax for various programming languages and file extensions.
 The constants in this file are used to determine the comment syntax for a given file when parsing source code for tag annotations.
 This will help determine if the tag annotation is within a single line comment or a multi-line comment.
+
+@TODO - Increase programming language support. Python, Haskel, etc.
 */
 package tag
 
-type LanguageCommentSyntax struct {
+type CommentLangSyntax struct {
 	SingleLineCommentSymbols string
 	MultiLineCommentSymbols  MultiLineCommentSyntax
 }
@@ -15,8 +17,7 @@ type MultiLineCommentSyntax struct {
 	CommentEndSymbol   string
 }
 
-// @TODO - Increase programming language support. Python, Haskel, etc.
-var CommentSyntaxMap = map[string]LanguageCommentSyntax{
+var CommentSyntaxMap = map[string]CommentLangSyntax{
 	"c-derived": {
 		SingleLineCommentSymbols: CommentCSingle,
 		MultiLineCommentSymbols: MultiLineCommentSyntax{
@@ -29,7 +30,7 @@ var CommentSyntaxMap = map[string]LanguageCommentSyntax{
 	},
 }
 
-func GetCommentSyntax(fileExtension string) LanguageCommentSyntax {
+func CommentSyntax(fileExtension string) CommentLangSyntax {
 	switch fileExtension {
 	case FileExtC,
 		FileExtCpp,

--- a/pkg/tag/comment_test.go
+++ b/pkg/tag/comment_test.go
@@ -27,21 +27,20 @@ func TestGetCommentSyntax_CLanguages(t *testing.T) {
 	}
 
 	for _, ext := range fileExtensions {
-		commentSyntax := tag.GetCommentSyntax(ext)
+		commentSyntax := tag.CommentSyntax(ext)
 		require.Equal(t, tag.CommentSyntaxMap["c-derived"], commentSyntax)
 	}
 }
 
 func TestGetCommentSyntax_Default(t *testing.T) {
 	unrecognizedExtensions := []string{
-		".txt",
 		".gitignore",
 		"LICENSE",
 		"Makefile",
 	}
 
 	for _, ext := range unrecognizedExtensions {
-		commentSyntax := tag.GetCommentSyntax(ext)
+		commentSyntax := tag.CommentSyntax(ext)
 		require.Equal(t, tag.CommentSyntaxMap["default"], commentSyntax)
 	}
 }

--- a/pkg/tag/ignore.go
+++ b/pkg/tag/ignore.go
@@ -75,16 +75,13 @@ func formatIgnore(pattern string) string {
 		case '*':
 			res.WriteRune('.')
 			res.WriteRune('*')
-			break
 		case '.':
 			if strings.HasSuffix(res.String(), "*") {
 				res.WriteRune('\\')
 			}
 			res.WriteRune('.')
-			break
 		default:
 			res.WriteRune(v)
-			break
 		}
 	}
 

--- a/pkg/tag/ignore_test.go
+++ b/pkg/tag/ignore_test.go
@@ -39,9 +39,9 @@ func TestProcessIgnorePatterns(t *testing.T) {
 	expectedLength := 4
 
 	expectedRegexpPatterns := []regexp.Regexp{
-		*regexp.MustCompile("\\/tmp"),
+		*regexp.MustCompile(`\/tmp`),
 		*regexp.MustCompile(".pnp.js"),
-		*regexp.MustCompile(".*\\.log"),
+		*regexp.MustCompile(`.*\.log`),
 		*regexp.MustCompile("src/old-impl/test/"),
 	}
 

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -84,7 +84,7 @@ func extractAnnotationDetails(scanner *bufio.Scanner, ext string, tag string) st
 	text := scanner.Text()
 	trimmedText := strings.TrimSpace(text)
 	hasAnnotation := strings.Contains(trimmedText, tag)
-	commentSyntax := GetCommentSyntax(ext)
+	commentSyntax := CommentSyntax(ext)
 
 	if strings.HasPrefix(trimmedText, commentSyntax.SingleLineCommentSymbols) && hasAnnotation {
 		description := strings.Join(strings.SplitAfter(trimmedText, tag), "")

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -13,7 +13,6 @@ type Tag struct {
 	StartLineNumber   uint64
 	EndLineNumber     uint64
 	AnnotationLineNum uint64
-	LineNumber        uint64
 	FileInfo          os.FileInfo
 }
 
@@ -67,9 +66,9 @@ func (pm *PendedTagManager) ScanForTags(detail ScanForTagsParams) ([]Tag, error)
 		tagDescription := extractAnnotationDetails(scanner, fileExtension, pm.TagName)
 		if tagDescription != "" {
 			tags = append(tags, Tag{
-				LineNumber:  lineNum + 1,
-				FileInfo:    detail.FileInfo,
-				Description: tagDescription,
+				AnnotationLineNum: lineNum + 1,
+				FileInfo:          detail.FileInfo,
+				Description:       tagDescription,
 			})
 		}
 		lineNum++

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -57,7 +57,6 @@ type ScanForTagsParams struct {
 	FileInfo os.FileInfo
 }
 
-// @TODO - Action Annotation test for development
 func (pm *PendedTagManager) ScanForTags(detail ScanForTagsParams) ([]Tag, error) {
 	tags := make([]Tag, 0)
 	lineNum := uint64(0)

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -57,6 +57,7 @@ type ScanForTagsParams struct {
 	FileInfo os.FileInfo
 }
 
+// @TODO - Action Annotation test for development
 func (pm *PendedTagManager) ScanForTags(detail ScanForTagsParams) ([]Tag, error) {
 	tags := make([]Tag, 0)
 	lineNum := uint64(0)

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -9,9 +9,12 @@ import (
 )
 
 type Tag struct {
-	LineNumber  uint64
-	Description string
-	FileInfo    os.FileInfo
+	Description       string
+	StartLineNumber   uint64
+	EndLineNumber     uint64
+	AnnotationLineNum uint64
+	LineNumber        uint64
+	FileInfo          os.FileInfo
 }
 
 type TagManager struct {

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -26,9 +26,7 @@ func TestScanForTags_SingleLineCommentEmpty(t *testing.T) {
 
 	ptm := tag.PendedTagManager{TagManager: tm}
 
-	tags, err := ptm.ScanForTags(
-		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
-	)
+	tags, err := ptm.ScanForTags(file.Name(), file, fileInfo)
 
 	require.NoError(t, err)
 	require.Empty(t, tags)
@@ -55,16 +53,15 @@ func TestScanForTags_SingleLineCommentOne(t *testing.T) {
 
 	ptm := tag.PendedTagManager{TagManager: tm}
 
-	tags, err := ptm.ScanForTags(
-		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
-	)
+	tags, err := ptm.ScanForTags(file.Name(), file, fileInfo)
 
 	tag := tags[0]
 
 	require.NoError(t, err)
 	require.Len(t, tags, 1)
 	require.Equal(t, tag.FileInfo, fileInfo)
-	require.Equal(t, tag.Description, "Add Game Loop")
+	require.Equal(t, tag.Title, "Add Game Loop")
+	require.Equal(t, tag.Description, "")
 	require.Equal(t, tag.StartLineNumber, uint64(6))
 	require.Equal(t, tag.EndLineNumber, uint64(6))
 	require.Equal(t, tag.AnnotationLineNum, uint64(6))
@@ -96,23 +93,23 @@ func TestScanForTags_SingleLineCommentMultiple(t *testing.T) {
 
 	ptm := tag.PendedTagManager{TagManager: tm}
 
-	tags, err := ptm.ScanForTags(
-		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
-	)
+	tags, err := ptm.ScanForTags(file.Name(), file, fileInfo)
 
 	expected := []tag.Tag{
 		{
 			AnnotationLineNum: uint64(6),
 			StartLineNumber:   uint64(6),
 			EndLineNumber:     uint64(7),
-			Description:       "Add feature X\nFeature X is ...",
+			Title:             "Add feature X",
+			Description:       "Feature X is ...",
 			FileInfo:          fileInfo,
 		},
 		{
 			AnnotationLineNum: uint64(10),
 			StartLineNumber:   uint64(10),
 			EndLineNumber:     uint64(11),
-			Description:       "Add feature Y\nFeature Y is ...",
+			Title:             "Add feature Y",
+			Description:       "Feature Y is ...",
 			FileInfo:          fileInfo,
 		},
 	}

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -51,5 +51,5 @@ func TestFindPendingTags_SingleLineComment(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, pendedTags, 1)
-	require.Equal(t, uint64(9), pendedTags[0].LineNumber)
+	require.Equal(t, uint64(9), pendedTags[0].AnnotationLineNum)
 }

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -8,28 +8,128 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindPendingTags_SingleLineComment(t *testing.T) {
-	file, err := os.CreateTemp("", "*.go")
+func TestScanForTags_SingleLineCommentEmpty(t *testing.T) {
+	file, fileInfo := setup(t,
+		`func main(){
+		// This is a comment with no annotation.
+		// Thus, there should not be a tag returned
+		return 0
+		}`,
+	)
+
+	defer tearDown(file)
+
+	tm := tag.TagManager{
+		TagName: "@TODO",
+		Mode:    "P", // Pending
+	}
+
+	ptm := tag.PendedTagManager{TagManager: tm}
+
+	tags, err := ptm.ScanForTags(
+		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
+	)
+
 	require.NoError(t, err)
+	require.Empty(t, tags)
+}
 
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	// Will test more languages, starting with `Go` for now
-	_, err = file.WriteString(`
-		package main
+func TestScanForTags_SingleLineCommentOne(t *testing.T) {
+	file, fileInfo := setup(t,
+		`package main
 
 		import "fmt"
 
 		func main() {
-			fmt.Printf("Hello World\n")
+			// @TODO Add Game Loop
+			return 0
+		}`,
+	)
 
-			// @TODO - Add Game Loop
-		}
-	`)
+	defer tearDown(file)
+
+	tm := tag.TagManager{
+		TagName: "@TODO",
+		Mode:    "P", // Pending
+	}
+
+	ptm := tag.PendedTagManager{TagManager: tm}
+
+	tags, err := ptm.ScanForTags(
+		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
+	)
+
+	tag := tags[0]
+
+	require.NoError(t, err)
+	require.Len(t, tags, 1)
+	require.Equal(t, tag.FileInfo, fileInfo)
+	require.Equal(t, tag.Description, "Add Game Loop")
+	require.Equal(t, tag.StartLineNumber, uint64(6))
+	require.Equal(t, tag.EndLineNumber, uint64(6))
+	require.Equal(t, tag.AnnotationLineNum, uint64(6))
+}
+
+func TestScanForTags_SingleLineCommentMultiple(t *testing.T) {
+	file, fileInfo := setup(t,
+		`package main
+
+		import "fmt"
+
+		func main() {
+			// @TODO Add feature X
+			// Feature X is ...
+
+
+			// @TODO Add feature Y
+			// Feature Y is ...
+			return 0
+		}`,
+	)
+
+	defer tearDown(file)
+
+	tm := tag.TagManager{
+		TagName: "@TODO",
+		Mode:    "P", // Pending
+	}
+
+	ptm := tag.PendedTagManager{TagManager: tm}
+
+	tags, err := ptm.ScanForTags(
+		tag.ScanForTagsParams{Path: file.Name(), File: file, FileInfo: fileInfo},
+	)
+
+	expected := []tag.Tag{
+		{
+			AnnotationLineNum: uint64(6),
+			StartLineNumber:   uint64(6),
+			EndLineNumber:     uint64(7),
+			Description:       "Add feature X\nFeature X is ...",
+			FileInfo:          fileInfo,
+		},
+		{
+			AnnotationLineNum: uint64(10),
+			StartLineNumber:   uint64(10),
+			EndLineNumber:     uint64(11),
+			Description:       "Add feature Y\nFeature Y is ...",
+			FileInfo:          fileInfo,
+		},
+	}
+
+	require.NoError(t, err)
+	require.Len(t, tags, 2)
+	require.Equal(t, expected, tags)
+}
+
+func setup(t *testing.T, fileText string) (*os.File, os.FileInfo) {
+	file, err := os.CreateTemp("", "*.go")
 	require.NoError(t, err)
 
-	err = file.Sync()
+	_, err = file.WriteString(fileText)
+	require.NoError(t, err)
+
+	err = file.Sync() // Check if this is needed
 	require.NoError(t, err)
 
 	_, err = file.Seek(0, 0)
@@ -38,18 +138,10 @@ func TestFindPendingTags_SingleLineComment(t *testing.T) {
 	fileInfo, err := file.Stat()
 	require.NoError(t, err)
 
-	tagManager := tag.TagManager{
-		TagName: "@TODO",
-		Mode:    "P", // Pending
-	}
-	pendedTagManager := tag.PendedTagManager{TagManager: tagManager}
+	return file, fileInfo
+}
 
-	pendedTags, err := pendedTagManager.ScanForTags(tag.ScanForTagsParams{
-		Path:     file.Name(),
-		File:     file,
-		FileInfo: fileInfo,
-	})
-	require.NoError(t, err)
-	require.Len(t, pendedTags, 1)
-	require.Equal(t, uint64(9), pendedTags[0].AnnotationLineNum)
+func tearDown(f *os.File) {
+	f.Close()
+	os.Remove(f.Name())
 }

--- a/pkg/tag/walk.go
+++ b/pkg/tag/walk.go
@@ -8,7 +8,7 @@ import (
 )
 
 type WalkTagManager interface {
-	ScanForTags(ScanForTagsParams) ([]Tag, error)
+	ScanForTags(path string, file *os.File, info os.FileInfo) ([]Tag, error)
 }
 
 type WalkFileOperator interface {
@@ -52,11 +52,7 @@ func Walk(arg WalkParams) ([]Tag, error) {
 			return err
 		}
 
-		foundTags, err := arg.TagManager.ScanForTags(ScanForTagsParams{
-			Path:     path,
-			File:     file,
-			FileInfo: fileInfo,
-		})
+		foundTags, err := arg.TagManager.ScanForTags(path, file, fileInfo)
 		if err != nil {
 			return err
 		}

--- a/pkg/tag/walk.go
+++ b/pkg/tag/walk.go
@@ -26,7 +26,7 @@ type WalkParams struct {
 func Walk(arg WalkParams) ([]Tag, error) {
 	tags := make([]Tag, 0)
 
-	err := arg.FileOperator.WalkDir(arg.Root, func(path string, d fs.DirEntry, err error) error {
+	err := arg.FileOperator.WalkDir(arg.Root, func(path string, d fs.DirEntry, wErr error) error {
 		isValidPath := validatePath(path, arg.IgnorePatterns)
 
 		if d.IsDir() {
@@ -63,8 +63,11 @@ func Walk(arg WalkParams) ([]Tag, error) {
 
 		tags = append(tags, foundTags...)
 
-		err = file.Close()
-		return err
+		if closeErr := file.Close(); closeErr != nil {
+			return closeErr
+		}
+
+		return wErr
 	})
 
 	return tags, err


### PR DESCRIPTION
# Features
- Support parsing of multiple comment annotations (as long as they are consecutive). 

Example of supporting multiple single line comments would be checking for a single line comment that has an annotation and then continuing to parse subsequent lines until all comments have been processed, see below:

```c
int main(){
  // @TODO Annotation Title (This line and below line are combined into one TagAnnotation object
  // description of the annotation. 

  // @TODO you could even have another one down here that would be tracked separably 
  return 0;
}
```

# Refactor 
- Adjusted the `ScanForTags` func to make it more modular. This will come in handy when we add in multi line comment parsing. 

Multi Line Parsing is denoted (in c like languages) using:

```c
/*
@ TODO I am a multi line comment
I need to be parsed in the next pull request : )
*/

int main(){
  return 0;
}
```