### PR TITLE
Multi Line Comment Annotation Parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3.7.0
+
       - name: Test
         run: go test -v ./...

--- a/pkg/tag/comment.go
+++ b/pkg/tag/comment.go
@@ -27,6 +27,10 @@ var CommentSyntaxMap = map[string]CommentLangSyntax{
 	},
 	"default": {
 		SingleLineCommentSymbols: "#",
+		MultiLineCommentSymbols: MultiLineCommentSyntax{
+			CommentStartSymbol: "#",
+			CommentEndSymbol:   "#",
+		},
 	},
 }
 


### PR DESCRIPTION
# Features

- Parse both single & multi line comments (c like languages for now) and search for actionable annotations.

## Example 

```c
/*
@TODO Validate the output from below function
Use ... as input 
*/

int traverseTaco(const char *beefType) { 
	if (strcmp(beefType, "carne asada") == 0) {
		return 1;
	}
	...
}
```

Above code snipet would produce an output of after the parser is finished:
```json
{
"title": "Validate the output from below function",
"description": "Use ... as input",
"startLineNumber": 2,
"endLineNumber": 5,
"annotationLineNumber": 3,
"fileName": "main.c"
}
```