### PR TITLE
Feat/report cmd

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -25,13 +25,12 @@ func (ReportManager) WalkDir(root string, fn fs.WalkDirFunc) error {
 	return filepath.WalkDir(root, fn)
 }
 
-// reportCmd represents the report command
 var ReportCmd = &cobra.Command{
 	Use:   "report",
 	Short: "report issues to a source code management system",
 	Long: `Scans source code files for Tag annotations and reports them
 	to a source code managment system of your choosing`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		path, err := cmd.Flags().GetString("path")
 		if err != nil {
 			ui.LogFatal(fmt.Errorf("Failed to read 'path' flag\n%s", err).Error())
@@ -84,7 +83,7 @@ var ReportCmd = &cobra.Command{
 		err = gc.User()
 		if err != nil {
 			ui.LogFatal(
-				fmt.Errorf("Failed to retrieve user.name from your global git config. See `git config global --help`", err).
+				fmt.Errorf("Failed to retrieve user.name from your global git config. See `git config global --help` %s", err).
 					Error(),
 			)
 		}

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -5,11 +5,25 @@ package report
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/tag"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
 	"github.com/spf13/cobra"
 )
+
+type ReportManager struct{}
+
+func (ReportManager) Open(fileName string) (*os.File, error) {
+	return os.Open(fileName)
+}
+
+func (ReportManager) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
 
 // reportCmd represents the report command
 var ReportCmd = &cobra.Command{
@@ -18,6 +32,53 @@ var ReportCmd = &cobra.Command{
 	Long: `Scans source code files for Tag annotations and reports them
 	to a source code managment system of your choosing`,
 	Run: func(cmd *cobra.Command, args []string) {
+		path, err := cmd.Flags().GetString("path")
+		if err != nil {
+			ui.LogFatal(fmt.Errorf("Failed to read 'path' flag\n%s", err).Error())
+		}
+
+		gitIgnorePath, err := cmd.Flags().GetString("gitignorePath")
+		if err != nil {
+			ui.LogFatal(fmt.Errorf("Failed to read 'gitignorePath' flag\n%s", err).Error())
+		}
+
+		tagName, err := cmd.Flags().GetString("tag")
+		if err != nil {
+			ui.LogFatal(fmt.Errorf("Failed to read 'tag' flag\n%s", err).Error())
+		}
+
+		if path == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				ui.LogFatal(fmt.Errorf("Failed to get working directory\n%s", err).Error())
+			}
+			path = wd
+		}
+
+		if gitIgnorePath == "" {
+			gitIgnorePath = filepath.Join(path, tag.GitIgnoreFile)
+		}
+
+		scanManager := ReportManager{}
+		ignorePatterns, err := tag.ProcessIgnorePatterns(gitIgnorePath, scanManager)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		tagManager := tag.TagManager{TagName: tagName}
+
+		pendingTagManager := tag.PendedTagManager{TagManager: tagManager}
+		_, err = tag.Walk(tag.WalkParams{
+			Root:           path,
+			TagManager:     &pendingTagManager,
+			FileOperator:   scanManager,
+			IgnorePatterns: ignorePatterns,
+		})
+
+		if err != nil {
+			ui.LogFatal(fmt.Errorf("Failed to scan your project.\n%s", err).Error())
+		}
+
 		gc := scm.GitConfig{}
 
 		err = gc.User()
@@ -35,9 +96,11 @@ var ReportCmd = &cobra.Command{
 					Error(),
 			)
 		}
-
 	},
 }
 
 func init() {
+	ReportCmd.Flags().StringP("path", "p", "", "Path to your local git project.")
+	ReportCmd.Flags().StringP("tag", "t", "@TODO", "Actionable comment tag to search for.")
+	ReportCmd.Flags().StringP("gitignorePath", "g", "", "Path to .gitignore file.")
 }

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -20,13 +20,22 @@ var ReportCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		gc := scm.GitConfig{}
 
-		err := gc.User()
+		err = gc.User()
 		if err != nil {
 			ui.LogFatal(
 				fmt.Errorf("Failed to retrieve user.name from your global git config. See `git config global --help`", err).
 					Error(),
 			)
 		}
+
+		err = gc.RepoName()
+		if err != nil {
+			ui.LogFatal(
+				fmt.Errorf("Failed to retrieve git remote origin url. %s", err).
+					Error(),
+			)
+		}
+
 	},
 }
 

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -18,6 +18,15 @@ var ReportCmd = &cobra.Command{
 	Long: `Scans source code files for Tag annotations and reports them
 	to a source code managment system of your choosing`,
 	Run: func(cmd *cobra.Command, args []string) {
+		gc := scm.GitConfig{}
+
+		err := gc.User()
+		if err != nil {
+			ui.LogFatal(
+				fmt.Errorf("Failed to retrieve user.name from your global git config. See `git config global --help`", err).
+					Error(),
+			)
+		}
 	},
 }
 

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -28,8 +28,8 @@ func (ReportManager) WalkDir(root string, fn fs.WalkDirFunc) error {
 var ReportCmd = &cobra.Command{
 	Use:   "report",
 	Short: "report issues to a source code management system",
-	Long: `Scans source code files for Tag annotations and reports them
-	to a source code managment system of your choosing`,
+	Long: `Scans source code files for Tag annotations and reports them, as trackable issues,
+	to a source code managment system of your choosing.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		path, err := cmd.Flags().GetString("path")
 		if err != nil {

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -15,6 +15,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	ReportCmd.Flags().StringP("path", "p", "", "Path to your local git project.")
+	ReportCmd.Flags().StringP("tag", "t", "@TODO", "Actionable comment tag to search for.")
+	ReportCmd.Flags().StringP("gitignorePath", "g", "", "Path to .gitignore file.")
+}
+
 type ReportManager struct{}
 
 func (ReportManager) Open(fileName string) (*os.File, error) {

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -1,0 +1,25 @@
+/*
+Copyright © 2024 AntoninoAdornetto
+*/
+package report
+
+import (
+	"fmt"
+
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+// reportCmd represents the report command
+var ReportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "report issues to a source code management system",
+	Long: `Scans source code files for Tag annotations and reports them
+	to a source code managment system of your choosing`,
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}
+
+func init() {
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/AntoninoAdornetto/issue-summoner/cmd/report"
 	"github.com/AntoninoAdornetto/issue-summoner/cmd/scan"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
 	"github.com/spf13/cobra"
@@ -48,6 +49,7 @@ func Execute() {
 
 func subCommands() {
 	rootCmd.AddCommand(scan.ScanCmd)
+	rootCmd.AddCommand(report.ReportCmd)
 }
 
 func init() {

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -1,0 +1,26 @@
+package scm
+
+import (
+	"os/exec"
+	"strings"
+)
+
+type GitConfig struct {
+	UserName       string
+	RepositoryName string
+	Token          string
+}
+
+func (gc *GitConfig) User() error {
+	var out strings.Builder
+	cmd := exec.Command("git", "config", "--global", "user.name")
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	gc.UserName = out.String()
+	return nil
+}

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -24,3 +24,37 @@ func (gc *GitConfig) User() error {
 	gc.UserName = out.String()
 	return nil
 }
+
+func (gc *GitConfig) RepoName() error {
+	var out strings.Builder
+	cmd := exec.Command("git", "remote", "-v")
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	gc.RepositoryName = extractRepoName(out.String())
+	return nil
+}
+
+// extractRepoName takes the output from the `git remote -v` command as input (origins) and outputs the repository name.
+// The function can handle both ssh and https origins.
+// Git does not offer a command that outputs the repository name directly
+func extractRepoName(origins string) string {
+	for _, line := range strings.Split(origins, "\n") {
+		if strings.Contains(line, "(push)") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				repoURL := fields[1]
+				parts := strings.Split(repoURL, "/")
+				if len(parts) > 1 {
+					repo := strings.TrimSuffix(parts[len(parts)-1], ".git")
+					return repo
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/ui/multi_select.go
+++ b/pkg/ui/multi_select.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Selection struct {
+	Options map[string]bool
+}
+
+type Step struct {
+	StepName string
+	Options  []Item
+	Headers  string
+	Field    string
+}
+
+type Item struct {
+	Flag, Title, Desc string
+}
+
+func (s *Selection) OnSelect(option string, value bool) {
+	s.Options[option] = value
+}
+
+type model struct {
+	cursor   int
+	options  []Item
+	selected map[int]struct{}
+	choices  *Selection
+	header   string
+	exit     *bool
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func InitialModelMultiSelect(
+	options []Item,
+	selection *Selection,
+	header string,
+	program *bool,
+) model {
+	return model{
+		options:  options,
+		selected: make(map[int]struct{}),
+		choices:  selection,
+		header:   AccentTextStyle.Render(header),
+		exit:     program,
+	}
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			*m.exit = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			_, ok := m.selected[m.cursor]
+			if ok {
+				delete(m.selected, m.cursor)
+			} else {
+				m.selected[m.cursor] = struct{}{}
+			}
+		case "y":
+			for selectedKey := range m.selected {
+				m.choices.OnSelect(m.options[selectedKey].Flag, true)
+				m.cursor = selectedKey
+			}
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m model) View() string {
+	s := m.header + "\n\n"
+
+	for i, option := range m.options {
+		cursor := " "
+		if m.cursor == i {
+			cursor = SuccessTextStyle.Render(">")
+			option.Title = PrimaryTextStyle.Render(option.Title)
+			option.Desc = PrimaryTextStyle.Render(option.Desc)
+		}
+
+		checked := " "
+		if _, ok := m.selected[i]; ok {
+			checked = SecondaryTextStyle.Render("*")
+		}
+
+		title := DimTextStyle.Render(option.Title)
+		description := DimTextStyle.Render(option.Desc)
+
+		s += fmt.Sprintf("%s [%s] %s\n%s\n\n", cursor, checked, title, description)
+	}
+
+	s += fmt.Sprintf("Press %s to confirm choice.\n", AccentTextStyle.Render("y"))
+	return s
+}


### PR DESCRIPTION
# Features

- init a new command (`report`) that will allow the user to submit pending tag annotations to a source code management system of their choosing. (The reporting functionality is still being worked on and is not working as of yet)
- Display all located tag annotations and allow the user to select which ones they would like to submit as issues. 
- Persist the git username and repo name (will be used to open issues via command line) 