### PR TITLE
Chore/flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <h3 align="center">Go Issue Summoner</h3>
 
   <p align="center">
-    Transform your todo comments into trackable issues that are reported to a source code management system of your choosing.
+    Turn your comments into trackable issues that are reported to your favorite source code management system. 
     <br />
     <!-- @TODO Uncomment 'explore docs' section once we have added documentation. -->
     <!-- <a href="https://github.com/AntoninoAdornetto/go-issue-summoner"><strong>Explore the docs »</strong></a> -->
@@ -175,7 +175,7 @@ Running the above command will provide a multi select option where you can choos
 - [x] `Authenticate User to submit issues`: Verify and Authenticate a user to allow the program to submit issues on the users behalf.
 
   - [x] GitHub Device Flow
-  - [ ] GitLabl
+  - [ ] GitLab
   - [ ] BitBucket
         <br></br>
 

--- a/cmd/authorize.go
+++ b/cmd/authorize.go
@@ -1,7 +1,7 @@
 /*
 Copyright © 2024 AntoninoAdornetto
 */
-package authorize
+package cmd
 
 import (
 	"bufio"

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,7 +1,7 @@
 /*
 Copyright © 2024 AntoninoAdornetto
 */
-package report
+package cmd
 
 import (
 	"fmt"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/AntoninoAdornetto/issue-summoner/cmd/authorize"
-	"github.com/AntoninoAdornetto/issue-summoner/cmd/report"
-	"github.com/AntoninoAdornetto/issue-summoner/cmd/scan"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
 	"github.com/spf13/cobra"
 )
@@ -48,9 +45,9 @@ func Execute() {
 }
 
 func subCommands() {
-	rootCmd.AddCommand(scan.ScanCmd)
-	rootCmd.AddCommand(report.ReportCmd)
-	rootCmd.AddCommand(authorize.AuthorizeCmd)
+	rootCmd.AddCommand(ScanCmd)
+	rootCmd.AddCommand(ReportCmd)
+	rootCmd.AddCommand(AuthorizeCmd)
 }
 
 func init() {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -5,7 +5,7 @@ The scan command processes each source file individually and searches for specif
 It respects the `.gitignore` settings and ensures that any files designated as ignored are not scanned.
 Finally, a detailed report is presented to the user about the tags that were found during the scan.
 */
-package scan
+package cmd
 
 import (
 	"fmt"


### PR DESCRIPTION
# Changes

move sub commands into the cmd package instead of placing them in their own directories. Not sure why I did this originally. 

updated readme documentation 