### PR TITLE
fix: issue desc not uploaded to github

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -144,7 +144,7 @@ var ReportCmd = &cobra.Command{
 
 		for _, t := range tags {
 			if selection.Options[t.Title] {
-				toReport = append(toReport, scm.Issue{Title: t.Title, Description: t.Description})
+				toReport = append(toReport, scm.Issue{Title: t.Title, Body: t.Description})
 			}
 		}
 

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -28,8 +28,8 @@ type GitConfig struct {
 }
 
 type Issue struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
 }
 
 // GitConfigManager interface allows us to have different adapters for each


### PR DESCRIPTION
I mixed up the request params for creating an issue on GitHub. The problem was I needed to use `body` instead of `description`